### PR TITLE
Perform write to cassandra asynchronously

### DIFF
--- a/src/main/java/net/explorviz/trace/kafka/SpanPersistingStream.java
+++ b/src/main/java/net/explorviz/trace/kafka/SpanPersistingStream.java
@@ -124,7 +124,7 @@ public class SpanPersistingStream {
 
     traceStream.foreach((k, t) -> {
           try {
-            repository.saveTrace(t);
+            repository.saveTraceAsync(t);
             pfLogger.logOperation();
           } catch (PersistingException e) {
             // TODO: How to handle these spans? Enqueue somewhere for retries?

--- a/src/main/java/net/explorviz/trace/persistence/SpanRepository.java
+++ b/src/main/java/net/explorviz/trace/persistence/SpanRepository.java
@@ -1,10 +1,12 @@
 package net.explorviz.trace.persistence;
 
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 import net.explorviz.avro.SpanDynamic;
 import net.explorviz.avro.Trace;
 
@@ -21,6 +23,8 @@ public interface SpanRepository {
   void insert(SpanDynamic span) throws PersistingException;
 
   void saveTrace(Trace trace) throws PersistingException;
+
+  CompletionStage<AsyncResultSet> saveTraceAsync(Trace trace) throws PersistingException;
 
   /**
    * Finds a trace for a given a landscape token and trace id.

--- a/src/test/java/net/explorviz/trace/kafka/SpanPersistingStreamTest.java
+++ b/src/test/java/net/explorviz/trace/kafka/SpanPersistingStreamTest.java
@@ -94,7 +94,7 @@ class SpanPersistingStreamTest {
       Trace inserted = i.getArgumentAt(0, Trace.class);
       mockSpanDB.add(inserted);
       return null;
-    }).when(mockRepo).saveTrace(Mockito.any());
+    }).when(mockRepo).saveTraceAsync(Mockito.any());
 
     SpanDynamic testSpan = TraceHelper.randomSpan();
     inputTopic.pipeInput(testSpan.getTraceId(), testSpan);
@@ -114,7 +114,7 @@ class SpanPersistingStreamTest {
       String key = inserted.getLandscapeToken() + "::" + inserted.getTraceId();
       mockSpanDB.put(key, inserted);
       return null;
-    }).when(mockRepo).saveTrace(Mockito.any());
+    }).when(mockRepo).saveTraceAsync(Mockito.any());
 
     int spansPerTrace = 20;
 
@@ -140,7 +140,7 @@ class SpanPersistingStreamTest {
       String key = inserted.getLandscapeToken() + "::" + inserted.getTraceId();
       mockSpanDB.put(key, inserted);
       return null;
-    }).when(mockRepo).saveTrace(Mockito.any());
+    }).when(mockRepo).saveTraceAsync(Mockito.any());
 
     int spansPerTrace = 20;
     int traceAmount = 20;
@@ -182,7 +182,7 @@ class SpanPersistingStreamTest {
       });
       mockSpanDB.putIfAbsent(key, inserted);
       return null;
-    }).when(mockRepo).saveTrace(Mockito.any());
+    }).when(mockRepo).saveTraceAsync(Mockito.any());
 
     int spansPerTrace = 20;
 

--- a/src/test/java/net/explorviz/trace/persistence/cassandra/CassandraSpanRepositoryTest.java
+++ b/src/test/java/net/explorviz/trace/persistence/cassandra/CassandraSpanRepositoryTest.java
@@ -3,6 +3,7 @@ package net.explorviz.trace.persistence.cassandra;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +54,15 @@ class CassandraSpanRepositoryTest extends CassandraTest {
   }
 
   @Test
+  void saveTraceAsync() throws PersistingException {
+    Trace t = TraceHelper.randomTrace(20);
+
+    repo.saveTraceAsync(t).toCompletableFuture().join();
+    Collection<SpanDynamic> got = repo.getSpans(t.getLandscapeToken(), t.getTraceId()).orElseThrow();
+    Assertions.assertEquals(20, got.size());
+  }
+
+  @Test
   void insertSingleTrace() throws PersistingException {
     final int spansPerTrace = 20;
     Trace testTrace = TraceHelper.randomTrace(spansPerTrace);
@@ -83,6 +93,7 @@ class CassandraSpanRepositoryTest extends CassandraTest {
 
     Assertions.assertEquals(expected, gotList);
   }
+
 
   @Test
   void insertMultipleTraces() throws PersistingException {


### PR DESCRIPTION
Fixes #12 by performing all writes (inserting new traces) to the cassandra database asynchronously.